### PR TITLE
Moved block logic into its own method so that the lock is released be…

### DIFF
--- a/fail2ban.go
+++ b/fail2ban.go
@@ -215,7 +215,12 @@ func (u *Fail2Ban) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		u.next.ServeHTTP(rw, req)
 		return
 	}
+	HandleRequest(rw, req);
+	
+	u.next.ServeHTTP(rw, req)
+}
 
+func (u *Fail2Ban) HandleRequest(rw http.ResponseWriter, req *http.Request) {
 	remoteIP, _, err := net.SplitHostPort(req.RemoteAddr)
 	if err != nil {
 		LoggerDEBUG.Println(remoteIP + " is not a valid IP or a IP/NET")
@@ -294,5 +299,4 @@ func (u *Fail2Ban) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			LoggerDEBUG.Printf("welcome back %s", remoteIP)
 		}
 	}
-	u.next.ServeHTTP(rw, req)
 }


### PR DESCRIPTION
Moved block logic into its own method so that the lock is released before sending the response content

Attempt at fixing #67, might also solve #59.

**_!!!!Note that I have no knowledge or experience of GO so the code might not even compile!!!!_** 