### PR TITLE
Minor updates to README to make behaviour a bit more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,36 @@
 
 [![Build Status](https://github.com/tomMoulard/fail2ban/actions/workflows/main.yml/badge.svg)](https://github.com/tomMoulard/fail2ban/actions/workflows/main.yml)
 
-This plugin is an implementation of the fail2ban mechanism as a middleware
+This plugin is an implementation of a Fail2ban instance as a middleware
 plugin for Traefik.
 
+## Middleware
+
+After installing the plugin, it can be configured through a Middleware, e.g.:
+
+```yml
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: fail2ban-test
+spec:
+  plugin:
+    fail2ban:
+      blacklist:
+        logLevel: DEBUG
+        ip: 127.0.0.1
+```
+
+Don't forget to add the middleware to your Route (and since middlewares are
+checked in the same order as they are listed, make sure that the middleware is
+up in your list).
+
 ## Configuration
+
+Please note that the whitelist and blacklist functionality described below can
+_only_ be used _concurrently_ with Fail2ban functionality (if you are looking
+for a way to whitelist or blacklist IPs without using any of the Fail2ban
+logic, you might want to use a different plugin.)
 
 ### Whitelist
 You can whitelist some IP using this:
@@ -22,6 +48,8 @@ testData:
 Where you can use some IP in an array of files or directly in the
 configuration.
 
+If you have a single IP, this: `ip: 127.0.0.1` should also work.
+
 ### Blacklist
 Like whitelist, you can blacklist some IP using this:
 ```yml
@@ -37,6 +65,8 @@ testData:
 Where you can use some IP in an array of files or directly in the
 configuration.
 
+Please note that Fail2ban logs will _only_ be visible when Traefik's log level
+is set to `DEBUG`.
 
 ## Fail2ban
 We plan to use all default fail2ban configuration but at this time only a

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ plugin for Traefik.
 After installing the plugin, it can be configured through a Middleware, e.g.:
 
 ```yml
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: fail2ban-test
@@ -22,9 +22,28 @@ spec:
         ip: 127.0.0.1
 ```
 
-Don't forget to add the middleware to your Route (and since middlewares are
-checked in the same order as they are listed, make sure that the middleware is
-up in your list).
+<details>
+<summary>Add the middleware to an ingressroute</summary>
+
+```yml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: simplecrd
+  namespace: default
+spec:
+  entryPoints:
+    - web
+  routes:
+  - match: Host(`fail2ban.localhost`)
+    kind: Rule
+    middlewares:
+    - name: fail2ban-test
+    services:
+    ...
+```
+
+</details>
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ metadata:
 spec:
   plugin:
     fail2ban:
+      logLevel: DEBUG
       blacklist:
-        logLevel: DEBUG
         ip: 127.0.0.1
 ```
 


### PR DESCRIPTION
While trying out the plugin I noticed a few things that would need a bit of clarification in the README, so I have taken the liberty to propose some changes to the docs.

In detail:
* `ip` can be used without the array
* a few details on the structure of the Middleware (this will be very obvious to most Traefik users, but better safe than sorry)
* a reminder on the priorities of Middleware(s) and Route(s)
* the logging setting of the plugin is subject to Traefik's generic logging settings