### PR TITLE
Replace net.IPNet to netip.Prefix for performances purposes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,4 +73,4 @@ issues:
     - path: 'fail2ban.go'
       text: 'Function ''ServeHTTP'' has too many statements'
     - path: 'fail2ban.go'
-      text: 'calculated cyclomatic complexity for function ServeHTTP'
+      text: 'calculated cyclomatic complexity for function ServeHTTP is 16'

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ lint:
 	golangci-lint run
 
 .PHONY: test
+TEST_ARGS ?= -v -cover -race
 test:
-	go test -v -cover ./...
+	go test ${TEST_ARGS} ./...
 
 .PHONY: yaegi_test
 yaegi_test:

--- a/fail2ban.go
+++ b/fail2ban.go
@@ -137,8 +137,8 @@ func TransformRule(r Rules) (RulesTransformed, error) {
 type Fail2Ban struct {
 	next      http.Handler
 	name      string
-	whitelist []ipchecking.NetIP
-	blacklist []ipchecking.NetIP
+	whitelist ipchecking.NetIPs
+	blacklist ipchecking.NetIPs
 	rules     RulesTransformed
 }
 
@@ -229,23 +229,19 @@ func (u *Fail2Ban) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// Blacklist
-	for _, ip := range u.blacklist {
-		if ip.Contains(remoteIP) {
-			LoggerDEBUG.Println(remoteIP + " is blacklisted")
-			rw.WriteHeader(http.StatusForbidden)
+	if u.blacklist.Contains(remoteIP) {
+		LoggerDEBUG.Println(remoteIP + " is blacklisted")
+		rw.WriteHeader(http.StatusForbidden)
 
-			return
-		}
+		return
 	}
 
 	// Whitelist
-	for _, ip := range u.whitelist {
-		if ip.Contains(remoteIP) {
-			LoggerDEBUG.Println(remoteIP + " is whitelisted")
-			u.next.ServeHTTP(rw, req)
+	if u.whitelist.Contains(remoteIP) {
+		LoggerDEBUG.Println(remoteIP + " is whitelisted")
+		u.next.ServeHTTP(rw, req)
 
-			return
-		}
+		return
 	}
 
 	// Urlregexp ban

--- a/fail2ban.go
+++ b/fail2ban.go
@@ -185,7 +185,7 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 		return nil, err
 	}
 
-	whitelist, err := ipchecking.StrToIP(whiteips)
+	whitelist, err := ipchecking.ParseNetIPs(whiteips)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse whitelist IPs: %w", err)
 	}
@@ -195,7 +195,7 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 		return nil, err
 	}
 
-	blacklist, err := ipchecking.StrToIP(blackips) // Do not mistake with Black Eyed Peas
+	blacklist, err := ipchecking.ParseNetIPs(blackips) // Do not mistake with Black Eyed Peas
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse blacklist IPs: %w", err)
 	}

--- a/fail2ban.go
+++ b/fail2ban.go
@@ -137,8 +137,8 @@ func TransformRule(r Rules) (RulesTransformed, error) {
 type Fail2Ban struct {
 	next      http.Handler
 	name      string
-	whitelist []ipchecking.IP
-	blacklist []ipchecking.IP
+	whitelist []ipchecking.NetIP
+	blacklist []ipchecking.NetIP
 	rules     RulesTransformed
 }
 
@@ -230,7 +230,7 @@ func (u *Fail2Ban) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Blacklist
 	for _, ip := range u.blacklist {
-		if ip.CheckIPInSubnet(remoteIP) {
+		if ip.Contains(remoteIP) {
 			LoggerDEBUG.Println(remoteIP + " is blacklisted")
 			rw.WriteHeader(http.StatusForbidden)
 
@@ -240,7 +240,7 @@ func (u *Fail2Ban) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Whitelist
 	for _, ip := range u.whitelist {
-		if ip.CheckIPInSubnet(remoteIP) {
+		if ip.Contains(remoteIP) {
 			LoggerDEBUG.Println(remoteIP + " is whitelisted")
 			u.next.ServeHTTP(rw, req)
 

--- a/ipchecking/ipChecking.go
+++ b/ipchecking/ipChecking.go
@@ -15,8 +15,9 @@ type NetIP struct {
 	Addr netip.Addr
 }
 
-// StrToIP convert ip string array to ip struct array.
-func StrToIP(iplist []string) ([]NetIP, error) {
+// ParseNetIPs Parse a slice string to extract the netip.
+// Returns an error on the first IP that failed to parse.
+func ParseNetIPs(iplist []string) ([]NetIP, error) {
 	rlist := make([]NetIP, 0, len(iplist))
 
 	for _, v := range iplist {

--- a/ipchecking/ipChecking.go
+++ b/ipchecking/ipChecking.go
@@ -1,32 +1,28 @@
-// Package ipchecking contains the IP checking mechanism for the plugin.
+// Package ipchecking wrapper over net/netip to handle both IP and CIRD.
 package ipchecking
 
 import (
 	"fmt"
 	"log"
-	"net"
-	"os"
+	"net/netip"
 	"strings"
 )
 
-// Logger ip checking logger.
-var Logger = log.New(os.Stdout, "IPChecking: ", log.Ldate|log.Ltime|log.Lshortfile)
-
-// IP struct that holds an IP Addr.
-type IP struct {
-	Net *net.IPNet
+// NetIP struct that holds an NetIP IP address, and a IP network.
+// If the network is nil, the NetIP is a single IP.
+type NetIP struct {
+	Net  *netip.Prefix
+	Addr netip.Addr
 }
 
 // StrToIP convert ip string array to ip struct array.
-func StrToIP(iplist []string) ([]IP, error) {
-	rlist := []IP{}
+func StrToIP(iplist []string) ([]NetIP, error) {
+	rlist := make([]NetIP, 0, len(iplist))
 
 	for _, v := range iplist {
-		ip, err := BuildIP(v)
+		ip, err := ParseNetIP(v)
 		if err != nil {
-			Logger.Printf("Error: %s not valid", v)
-
-			continue
+			return nil, fmt.Errorf("failed to parse %q: %w", v, err)
 		}
 
 		rlist = append(rlist, ip)
@@ -35,50 +31,47 @@ func StrToIP(iplist []string) ([]IP, error) {
 	return rlist, nil
 }
 
-func isIPv4(ip string) bool {
-	return strings.Contains(ip, ".")
-}
-
-// BuildIP Parse a string to extract the IP.
-func BuildIP(ip string) (IP, error) {
-	var res IP
-
-	var err error
-
+// ParseNetIP Parse a string to extract the netip.
+func ParseNetIP(ip string) (NetIP, error) {
 	tmpSubnet := strings.Split(ip, "/")
 	if len(tmpSubnet) == 1 {
-		tempIP := net.ParseIP(ip)
-		if tempIP == nil {
-			Logger.Printf("%s is not a valid IP or IP/Net", ip)
-
-			return res, fmt.Errorf("%s is not a valid IP or IP/Net", ip)
+		tempIP, err := netip.ParseAddr(ip)
+		if err != nil {
+			return NetIP{}, fmt.Errorf("failed to parse %q: %s", ip, err.Error())
 		}
 
-		if isIPv4(ip) {
-			ip += "/32"
-		} else {
-			ip += "/128"
-		}
+		return NetIP{Addr: tempIP}, nil
 	}
 
-	_, ipNet, err := net.ParseCIDR(ip)
+	ipNet, err := netip.ParsePrefix(ip)
 	if err != nil {
-		Logger.Printf("%e", err)
-
-		return res, fmt.Errorf("failed to parse CIDR: %w", err)
+		return NetIP{}, fmt.Errorf("failed to parse CIDR %q: %w", ip, err)
 	}
 
-	res.Net = ipNet
-
-	return res, nil
+	return NetIP{Net: &ipNet}, nil
 }
 
-// ToString convert IP struct to string.
-func (ip IP) ToString() string {
+// String convert IP struct to string.
+func (ip NetIP) String() string {
+	if ip.Net == nil {
+		return ip.Addr.String()
+	}
+
 	return ip.Net.String()
 }
 
-// CheckIPInSubnet Check is the IP Is the same or in the same subnet.
-func (ip IP) CheckIPInSubnet(i string) bool {
-	return ip.Net.Contains(net.ParseIP(i))
+// Contains Check is the IP Is the same or in the same subnet.
+func (ip NetIP) Contains(i string) bool {
+	rip, err := netip.ParseAddr(i)
+	if err != nil {
+		log.Printf("%s is not a valid IP or IP/Net: %s", i, err.Error())
+
+		return false
+	}
+
+	if ip.Net == nil {
+		return ip.Addr == rip
+	}
+
+	return ip.Net.Contains(rip)
 }

--- a/ipchecking/ipChecking.go
+++ b/ipchecking/ipChecking.go
@@ -1,4 +1,4 @@
-// Package ipchecking wrapper over net/netip to handle both IP and CIRD.
+// Package ipchecking wrapper over net/netip to compare both IP and CIRD.
 package ipchecking
 
 import (
@@ -17,7 +17,7 @@ type NetIP struct {
 
 // ParseNetIPs Parse a slice string to extract the netip.
 // Returns an error on the first IP that failed to parse.
-func ParseNetIPs(iplist []string) ([]NetIP, error) {
+func ParseNetIPs(iplist []string) (NetIPs, error) {
 	rlist := make([]NetIP, 0, len(iplist))
 
 	for _, v := range iplist {
@@ -61,7 +61,7 @@ func (ip NetIP) String() string {
 	return ip.Net.String()
 }
 
-// Contains Check is the IP Is the same or in the same subnet.
+// Contains Check is the IP is the same or in the same subnet.
 func (ip NetIP) Contains(i string) bool {
 	rip, err := netip.ParseAddr(i)
 	if err != nil {
@@ -75,4 +75,32 @@ func (ip NetIP) Contains(i string) bool {
 	}
 
 	return ip.Net.Contains(rip)
+}
+
+type NetIPs []NetIP
+
+// Contains Check is the IP is the same or in the same subnet.
+func (netIPs NetIPs) Contains(ip string) bool {
+	rip, err := netip.ParseAddr(ip)
+	if err != nil {
+		log.Printf("failed to parse %q: %s", ip, err.Error())
+
+		return false
+	}
+
+	for _, netIP := range netIPs {
+		if netIP.Net == nil {
+			if netIP.Addr == rip {
+				return true
+			}
+
+			continue
+		}
+
+		if netIP.Net.Contains(rip) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/ipchecking/ipChecking_test.go
+++ b/ipchecking/ipChecking_test.go
@@ -15,92 +15,92 @@ func TestIPGeneration(t *testing.T) {
 		res      bool
 	}{
 		{
-			name:     "[IP] Valid IPv4",
+			name:     "Valid IPv4",
 			stringIP: "127.0.0.1",
 			res:      true,
 		},
 		{
-			name:     "[IP] Invalid IPv4 value 8 first bits",
+			name:     "Invalid IPv4 value 8 first bits",
 			stringIP: "25666.0.0.1",
 			res:      false,
 		},
 		{
-			name:     "[IP] Invalid IPv4 value 8 second bits",
+			name:     "Invalid IPv4 value 8 second bits",
 			stringIP: "127.4444.0.1",
 			res:      false,
 		},
 		{
-			name:     "[IP] Invalid IPv4 value 8 third bits",
+			name:     "Invalid IPv4 value 8 third bits",
 			stringIP: "127.0.4440.1",
 			res:      false,
 		},
 		{
-			name:     "[IP] Invalid IPv4 value 8 last bits",
+			name:     "Invalid IPv4 value 8 last bits",
 			stringIP: "127.0.0.1233",
 			res:      false,
 		},
 		{
-			name:     "[IP] Invalid IPv4 CIDR form",
+			name:     "Invalid IPv4 CIDR form",
 			stringIP: "127.0.0.1/22/34",
 			res:      false,
 		},
 		{
-			name:     "[CIDR] Invalid IPv4 CIDR ",
+			name:     "Invalid IPv4 CIDR ",
 			stringIP: "127.0.0.1/55",
 			res:      false,
 		},
 		{
-			name:     "[CIDR] Missing IPv4 CIDR ",
+			name:     "Missing IPv4 CIDR ",
 			stringIP: "127.0.0.1/",
 			res:      false,
 		},
 		{
-			name:     "[CIDR] Valid IPv4 CIDR ",
+			name:     "Valid IPv4 CIDR ",
 			stringIP: "127.0.0.1/23",
 			res:      true,
 		},
 		{
-			name:     "[IP] Valid IPv6",
+			name:     "Valid IPv6",
 			stringIP: "::1",
 			res:      true,
 		},
 		{
-			name:     "[IP] Invalid IPv6 value 8 first bits",
+			name:     "Invalid IPv6 value 8 first bits",
 			stringIP: "2566634::1",
 			res:      false,
 		},
 		{
-			name:     "[IP] Invalid IPv6 value 8 second bits",
+			name:     "Invalid IPv6 value 8 second bits",
 			stringIP: "127:444234564:0::1",
 			res:      false,
 		},
 		{
-			name:     "[IP] Invalid IPv6 value 8 third bits",
+			name:     "Invalid IPv6 value 8 third bits",
 			stringIP: "1::4440345::1",
 			res:      false,
 		},
 		{
-			name:     "[IP] Invalid IPv6 value 8 last bits",
+			name:     "Invalid IPv6 value 8 last bits",
 			stringIP: "::34561233",
 			res:      false,
 		},
 		{
-			name:     "[IP] Invalid IPv6 CIDR form",
+			name:     "Invalid IPv6 CIDR form",
 			stringIP: "::1/22/34",
 			res:      false,
 		},
 		{
-			name:     "[CIDR] Invalid IPv6 CIDR ",
+			name:     "Invalid IPv6 CIDR ",
 			stringIP: "::1/234",
 			res:      false,
 		},
 		{
-			name:     "[CIDR] Missing IPv6 CIDR ",
+			name:     "Missing IPv6 CIDR ",
 			stringIP: "::1/",
 			res:      false,
 		},
 		{
-			name:     "[CIDR] Valid IPv6 CIDR ",
+			name:     "Valid IPv6 CIDR ",
 			stringIP: "::1/53",
 			res:      true,
 		},
@@ -110,7 +110,7 @@ func TestIPGeneration(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := ipchecking.BuildIP(tt.stringIP)
+			_, err := ipchecking.ParseNetIP(tt.stringIP)
 			if (err != nil) == tt.res {
 				t.Errorf("wanted '%v' got '%v'", tt.res, (err == nil))
 			}
@@ -118,10 +118,10 @@ func TestIPGeneration(t *testing.T) {
 	}
 }
 
-func helpBuildIP(t *testing.T, ip string) ipchecking.IP {
+func helpBuildIP(t *testing.T, ip string) ipchecking.NetIP {
 	t.Helper()
 
-	nip, err := ipchecking.BuildIP(ip)
+	nip, err := ipchecking.ParseNetIP(ip)
 	if err != nil {
 		t.Errorf("Error in IP building: %s, with err %v", nip, err)
 	}
@@ -145,53 +145,53 @@ func TestIPChecking(t *testing.T) {
 	tests := []struct {
 		name     string
 		stringIP string
-		testedIP ipchecking.IP
+		testedIP ipchecking.NetIP
 		res      bool
 	}{
 		{
-			name:     "[IP] IPv4 match",
+			name:     "IPv4 match",
 			stringIP: "127.0.0.1",
 			testedIP: ipv4,
 			res:      true,
 		},
 		{
-			name:     "[IP] IPv4 No Match",
+			name:     "IPv4 No Match",
 			stringIP: "127.0.0.1",
 			testedIP: ipv42,
 			res:      false,
 		},
 		{
-			name:     "[CIDR] IPv4 No Match",
+			name:     "IPv4 No Match",
 			stringIP: "127.0.0.1",
 			testedIP: cidrv42,
 			res:      false,
 		},
 		{
-			name:     "[CIDR] IPv4 Match",
+			name:     "IPv4 Match",
 			stringIP: "127.0.0.1",
 			testedIP: cidrv41,
 			res:      true,
 		},
 		{
-			name:     "[IP] IPv6 match",
+			name:     "IPv6 match",
 			stringIP: "::1",
 			testedIP: ipv6,
 			res:      true,
 		},
 		{
-			name:     "[IP] IPv6 No Match",
+			name:     "IPv6 No Match",
 			stringIP: "::1",
 			testedIP: ipv62,
 			res:      false,
 		},
 		{
-			name:     "[CIDR] IPv6 No Match",
+			name:     "IPv6 No Match",
 			stringIP: "::1",
 			testedIP: cidrv62,
 			res:      false,
 		},
 		{
-			name:     "[CIDR] IPv6 Match",
+			name:     "IPv6 Match",
 			stringIP: "::1",
 			testedIP: cidrv61,
 			res:      true,
@@ -202,7 +202,7 @@ func TestIPChecking(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			r := tt.testedIP.CheckIPInSubnet(tt.stringIP)
+			r := tt.testedIP.Contains(tt.stringIP)
 			if r != tt.res {
 				t.Errorf("wanted '%v' got '%v'", tt.res, r)
 			}
@@ -210,51 +210,15 @@ func TestIPChecking(t *testing.T) {
 	}
 }
 
-func TestIPv4toString(t *testing.T) {
+func TestIPtoString(t *testing.T) {
 	t.Parallel()
 
-	ip, err := ipchecking.BuildIP("127.0.0.1")
+	ipv4, err := ipchecking.ParseNetIP("127.0.0.1/32")
 	if err != nil {
 		t.Errorf("Error in IP building: %s, with err %v", "127.0.0.1", err)
 	}
 
-	tests := []struct {
-		name     string
-		testedIP string
-		stringIP ipchecking.IP
-		res      bool
-	}{
-		{
-			name:     "[IP] Valid IPv4 string",
-			testedIP: "127.0.0.1/32",
-			stringIP: ip,
-			res:      true,
-		},
-		{
-			name:     "[IP] Invalid IPv4 string",
-			testedIP: "127.0.0.2/32",
-			stringIP: ip,
-			res:      false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			r := tt.stringIP.ToString()
-			if (r == tt.testedIP) != tt.res {
-				t.Errorf("wanted '%v' got '%v'", tt.res, r == tt.testedIP)
-			}
-		})
-	}
-}
-
-func TestIPv6toString(t *testing.T) {
-	t.Parallel()
-
-	ip, err := ipchecking.BuildIP("::1")
+	ipv6, err := ipchecking.ParseNetIP("::1/128")
 	if err != nil {
 		t.Errorf("Error in IP building: %s, with err %v", "::1", err)
 	}
@@ -262,19 +226,31 @@ func TestIPv6toString(t *testing.T) {
 	tests := []struct {
 		name     string
 		testedIP string
-		stringIP ipchecking.IP
+		stringIP ipchecking.NetIP
 		res      bool
 	}{
 		{
-			name:     "[IP] Valid IPv6 string",
-			testedIP: "::1/128",
-			stringIP: ip,
+			name:     "Valid IPv4 string",
+			testedIP: "127.0.0.1/32",
+			stringIP: ipv4,
 			res:      true,
 		},
 		{
-			name:     "[IP] Invalid IPv6 string",
+			name:     "Invalid IPv4 string",
+			testedIP: "127.0.0.2/32",
+			stringIP: ipv4,
+			res:      false,
+		},
+		{
+			name:     "Valid IPv6 string",
+			testedIP: "::1/128",
+			stringIP: ipv6,
+			res:      true,
+		},
+		{
+			name:     "Invalid IPv6 string",
 			testedIP: "::2/128",
-			stringIP: ip,
+			stringIP: ipv6,
 			res:      false,
 		},
 	}
@@ -284,9 +260,10 @@ func TestIPv6toString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			r := tt.stringIP.ToString()
+			r := tt.stringIP.String()
 			if (r == tt.testedIP) != tt.res {
-				t.Errorf("wanted '%v' got '%v'", tt.res, r == tt.testedIP)
+				t.Errorf("wanted '%v' got '%v' (when testing %q == %q)",
+					tt.res, r == tt.testedIP, r, tt.testedIP)
 			}
 		})
 	}


### PR DESCRIPTION
This PR replaces the usage of [net.IPNet](https://pkg.go.dev/net#IPNet) to [netip.Prefix](https://pkg.go.dev/net/netip#Prefix) for performances purposes.

Following the [netip doc](https://pkg.go.dev/net/netip):

> Compared to the [net.IP](https://pkg.go.dev/net#IP) type, [Addr](https://pkg.go.dev/net/netip#Addr) type takes less memory, is immutable, and is comparable (supports == and being a map key).

<details>
  <summary markdown="span">here are a few benchmarks (results may vary)</summary>

```
> go test -bench=. github.com/tomMoulard/fail2ban/ipchecking -test.run=Benchmark
goos: linux
goarch: amd64
pkg: github.com/tomMoulard/fail2ban/ipchecking
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkIPChecking_new-12    	 1000000	      1042 ns/op
BenchmarkIPChecking_old-12    	  512394	      2307 ns/op
PASS
ok  	github.com/tomMoulard/fail2ban/ipchecking	2.618s

```

```go

func BenchmarkIPChecking_new(b *testing.B) {
	tests := []struct {
		ip1    string
		ip2    string
		expect bool
	}{
		{ip1: "127.0.0.1", ip2: "127.0.0.1", expect: true},
		{ip1: "127.0.0.1", ip2: "127.0.0.2", expect: false},
		{ip1: "127.0.0.1/24", ip2: "127.0.0.2", expect: true},
		{ip1: "127.0.0.1/32", ip2: "127.0.0.2", expect: false},
		{ip1: "10.0.0.1/32", ip2: "127.0.0.2", expect: false},
		{ip1: "10.0.0.1/0", ip2: "127.0.0.2", expect: true},
		{ip1: "0.0.0.0", ip2: "127.0.0.2", expect: false},
	}

	for n := 0; n < b.N; n++ {
		for _, tt := range tests {
			ipv4, _ := ipchecking.ParseNetIP(tt.ip1)
			if ipv4.Contains(tt.ip2) != tt.expect {
				b.Logf("ip1: %s, ip2: %s", tt.ip1, tt.ip2)
				b.Errorf("wanted '%v' got '%v'", tt.expect, ipv4.Contains(tt.ip2))
			}
		}
	}
}

func BenchmarkIPChecking_old(b *testing.B) {
	tests := []struct {
		ip1    string
		ip2    string
		expect bool
	}{
		{ip1: "127.0.0.1", ip2: "127.0.0.1", expect: true},
		{ip1: "127.0.0.1", ip2: "127.0.0.2", expect: false},
		{ip1: "127.0.0.1/24", ip2: "127.0.0.2", expect: true},
		{ip1: "127.0.0.1/32", ip2: "127.0.0.2", expect: false},
		{ip1: "10.0.0.1/32", ip2: "127.0.0.2", expect: false},
		{ip1: "10.0.0.1/0", ip2: "127.0.0.2", expect: true},
		{ip1: "0.0.0.0", ip2: "127.0.0.2", expect: false},
	}

	for n := 0; n < b.N; n++ {
		for _, tt := range tests {
			ipv4, _ := ipchecking.BuildIP(tt.ip1)
			if ipv4.CheckIPInSubnet(tt.ip2) != tt.expect {
				b.Logf("ip1: %s, ip2: %s", tt.ip1, tt.ip2)
				b.Errorf("wanted '%v' got '%v'", tt.expect, ipv4.CheckIPInSubnet(tt.ip2))
			}
		}
	}
}
```
</details>

There is one breaking change in the ipchecking API (except for the functions renaming to be closer to netip function calls) that is `StrToIP` now breaks when some IPs are faulty instead of ignoring them.