### PR TITLE
Optimize regexp compilations

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -9,6 +9,14 @@ import (
 	"log"
 )
 
-func New(out io.Writer, prefix string, flag int) *log.Logger {
-	return nil
+type Logger struct {
+	*log.Logger
 }
+
+func New(out io.Writer, prefix string, flag int) Logger {
+	return Logger{}
+}
+
+func (l Logger) Printf(format string, v ...interface{}) {}
+
+func (l Logger) Println(v ...interface{}) {}

--- a/log/log_debug.go
+++ b/log/log_debug.go
@@ -9,6 +9,10 @@ import (
 	"log"
 )
 
-func New(out io.Writer, prefix string, flag int) *log.Logger {
-	return log.New(out, prefix, flag)
+type Logger struct {
+	*log.Logger
+}
+
+func New(out io.Writer, prefix string, flag int) Logger {
+	return Logger{log.New(out, prefix, flag)}
 }


### PR DESCRIPTION
URLRegexps are now compiled in the New() func instead of in the ServeHTTP() func which should also improve performances