### PR TITLE
feat: add url allow handler

### DIFF
--- a/fail2ban_test.go
+++ b/fail2ban_test.go
@@ -465,25 +465,6 @@ func TestShouldAllow(t *testing.T) {
 			expect:   true,
 		},
 		{
-			name: "allow regexp",
-			cfg: &Fail2Ban{
-				rules: RulesTransformed{
-					Bantime:        300 * time.Second,
-					URLRegexpAllow: []*regexp.Regexp{regexp.MustCompile("/test")}, // comment me.
-				},
-				ipViewed: map[string]IPViewed{
-					"10.0.0.0": {
-						viewed: time.Now(),
-						nb:     1,
-						denied: true,
-					},
-				},
-			},
-			remoteIP: "10.0.0.0",
-			reqURL:   "/test",
-			expect:   true,
-		},
-		{
 			name: "block regexp",
 			cfg: &Fail2Ban{
 				rules: RulesTransformed{

--- a/pkg/list/allow/allow.go
+++ b/pkg/list/allow/allow.go
@@ -15,7 +15,7 @@ import (
 )
 
 // l debug logger. noop by default.
-var l = logger.New(os.Stdout, "DEBUG: allow: ", log.Ldate|log.Ltime|log.Lshortfile)
+var l = logger.New(os.Stdout, "DEBUG: list allow: ", log.Ldate|log.Ltime|log.Lshortfile)
 
 type allow struct {
 	list ipchecking.NetIPs

--- a/pkg/list/deny/deny.go
+++ b/pkg/list/deny/deny.go
@@ -15,7 +15,7 @@ import (
 )
 
 // l debug logger. noop by default.
-var l = logger.New(os.Stdout, "DEBUG: deny: ", log.Ldate|log.Ltime|log.Lshortfile)
+var l = logger.New(os.Stdout, "DEBUG: list deny: ", log.Ldate|log.Ltime|log.Lshortfile)
 
 type deny struct {
 	list ipchecking.NetIPs

--- a/pkg/url/allow/allow.go
+++ b/pkg/url/allow/allow.go
@@ -1,0 +1,37 @@
+// Package allow is a middleware
+package allow
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+
+	"github.com/tomMoulard/fail2ban/pkg/chain"
+	logger "github.com/tomMoulard/fail2ban/pkg/log"
+)
+
+// l debug logger. noop by default.
+var l = logger.New(os.Stdout, "DEBUG: url allow: ", log.Ldate|log.Ltime|log.Lshortfile)
+
+type allow struct {
+	regs []*regexp.Regexp
+}
+
+func New(regs []*regexp.Regexp) *allow {
+	return &allow{regs: regs}
+}
+
+func (a *allow) ServeHTTP(w http.ResponseWriter, r *http.Request) (*chain.Status, error) {
+	for _, reg := range a.regs {
+		if reg.MatchString(r.URL.String()) {
+			l.Printf("url %s not allowed", r.URL.String())
+
+			return &chain.Status{Break: true}, nil
+		}
+	}
+
+	l.Printf("url %s not is allowed", r.URL.String())
+
+	return nil, nil
+}

--- a/pkg/url/allow/allow_test.go
+++ b/pkg/url/allow/allow_test.go
@@ -1,0 +1,51 @@
+package allow
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tomMoulard/fail2ban/pkg/chain"
+	"github.com/tomMoulard/fail2ban/pkg/data"
+)
+
+func TestAllow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		regs           []*regexp.Regexp
+		expectedStatus *chain.Status
+	}{
+		{
+			name: "allowed",
+			regs: []*regexp.Regexp{regexp.MustCompile(`^https://example.com/foo$`)},
+			expectedStatus: &chain.Status{
+				Break: true,
+			},
+		},
+		{
+			name: "denied",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := New(test.regs)
+
+			recorder := &httptest.ResponseRecorder{}
+			req := httptest.NewRequest(http.MethodGet, "https://example.com/foo", nil)
+			req, err := data.ServeHTTP(recorder, req)
+			require.NoError(t, err)
+
+			got, err := a.ServeHTTP(recorder, req)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedStatus, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR refacto a little more the fail2ban function by exporting the URLRegexpAllow in its own handler.
