### PR TITLE
feat: add status code handler

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,12 +12,14 @@ linters:
     - ireturn # Not relevant
     - nilnil # Not relevant
     - testpackage # Too strict
+    - cyclop # duplicate of gocyclo
 
 linters-settings:
   misspell:
     locale: US
   funlen:
     lines: -1
+    statements: 120
   depguard:
     rules:
       main:

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -19,3 +19,4 @@ testData:
     findtime: "10m"
     maxretry: 4
     enabled: true
+    statuscode: "400,401,403-499"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - --api.insecure=true
       - --providers.docker
       - --log.level=DEBUG
+      - --accesslog
       - --experimental.localPlugins.fail2ban-local.moduleName=github.com/tomMoulard/fail2ban
       - --experimental.plugins.fail2ban-registery.modulename=github.com/tomMoulard/fail2ban
       - --experimental.plugins.fail2ban-registery.version=v0.7.1
@@ -18,7 +19,8 @@ services:
 
   whoami:
     image: traefik/whoami # https://github.com/traefik/whoami
-    command: -name whoami
+    command: >-
+      -name whoami -verbose true
     labels:
       traefik.http.routers.fail2ban-local.rule: Host(`fail2ban-local.localhost`)
       traefik.http.routers.fail2ban-local.middlewares: fail2ban-local
@@ -32,6 +34,7 @@ services:
       traefik.http.middlewares.fail2ban-local.plugin.fail2ban-local.rules.urlregexps[0].mode: block
       traefik.http.middlewares.fail2ban-local.plugin.fail2ban-local.rules.urlregexps[1].regexp: /yes
       traefik.http.middlewares.fail2ban-local.plugin.fail2ban-local.rules.urlregexps[1].mode: allow
+      traefik.http.middlewares.fail2ban-local.plugin.fail2ban-local.rules.statuscode: "400,401,403-499"
 
       traefik.http.routers.fail2ban-registery.rule: Host(`fail2ban-registery.localhost`)
       traefik.http.routers.fail2ban-registery.middlewares: fail2ban-registery

--- a/fail2ban.go
+++ b/fail2ban.go
@@ -3,46 +3,25 @@ package fail2ban
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
-	"regexp"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/tomMoulard/fail2ban/pkg/chain"
-	"github.com/tomMoulard/fail2ban/pkg/data"
-	"github.com/tomMoulard/fail2ban/pkg/ipchecking"
+	"github.com/tomMoulard/fail2ban/pkg/fail2ban"
+	f2bHandler "github.com/tomMoulard/fail2ban/pkg/fail2ban/handler"
 	lAllow "github.com/tomMoulard/fail2ban/pkg/list/allow"
 	lDeny "github.com/tomMoulard/fail2ban/pkg/list/deny"
-	logger "github.com/tomMoulard/fail2ban/pkg/log"
+	"github.com/tomMoulard/fail2ban/pkg/response/status"
+	"github.com/tomMoulard/fail2ban/pkg/rules"
 	uAllow "github.com/tomMoulard/fail2ban/pkg/url/allow"
 	uDeny "github.com/tomMoulard/fail2ban/pkg/url/deny"
 )
 
 func init() {
 	log.SetOutput(os.Stdout)
-}
-
-// Urlregexp struct.
-type Urlregexp struct {
-	Regexp string `yaml:"regexp"`
-	Mode   string `yaml:"mode"`
-}
-
-// LoggerDEBUG debug logger. noop by default.
-var LoggerDEBUG = logger.New(os.Stdout, "DEBUG: Fail2Ban: ", log.Ldate|log.Ltime|log.Lshortfile)
-
-// Rules struct fail2ban config.
-type Rules struct {
-	Bantime    string      `yaml:"bantime"`  // exprimate in a smart way: 3m
-	Enabled    bool        `yaml:"enabled"`  // enable or disable the jail
-	Findtime   string      `yaml:"findtime"` // exprimate in a smart way: 3m
-	Maxretry   int         `yaml:"maxretry"`
-	Urlregexps []Urlregexp `yaml:"urlregexps"`
 }
 
 // List struct.
@@ -53,9 +32,9 @@ type List struct {
 
 // Config struct.
 type Config struct {
-	Denylist  List  `yaml:"denylist"`
-	Allowlist List  `yaml:"allowlist"`
-	Rules     Rules `yaml:"port"`
+	Denylist  List        `yaml:"denylist"`
+	Allowlist List        `yaml:"allowlist"`
+	Rules     rules.Rules `yaml:"port"`
 
 	// deprecated
 	Blacklist List `yaml:"blacklist"`
@@ -66,84 +45,12 @@ type Config struct {
 // CreateConfig populates the Config data object.
 func CreateConfig() *Config {
 	return &Config{
-		Rules: Rules{
+		Rules: rules.Rules{
 			Bantime:  "300s",
 			Findtime: "120s",
 			Enabled:  true,
 		},
 	}
-}
-
-// RulesTransformed transformed Rules struct.
-type RulesTransformed struct {
-	Bantime        time.Duration
-	Findtime       time.Duration
-	URLRegexpAllow []*regexp.Regexp
-	URLRegexpBan   []*regexp.Regexp
-	MaxRetry       int
-	Enabled        bool
-}
-
-// TransformRule morph a Rules object into a RulesTransformed.
-func TransformRule(r Rules) (RulesTransformed, error) {
-	bantime, err := time.ParseDuration(r.Bantime)
-	if err != nil {
-		return RulesTransformed{}, fmt.Errorf("failed to parse bantime duration: %w", err)
-	}
-
-	log.Printf("Bantime: %s", bantime)
-
-	findtime, err := time.ParseDuration(r.Findtime)
-	if err != nil {
-		return RulesTransformed{}, fmt.Errorf("failed to parse findtime duration: %w", err)
-	}
-
-	log.Printf("Findtime: %s", findtime)
-
-	var regexpAllow []*regexp.Regexp
-
-	var regexpBan []*regexp.Regexp
-
-	for _, rg := range r.Urlregexps {
-		log.Printf("using mode %q for rule %q", rg.Mode, rg.Regexp)
-
-		re, err := regexp.Compile(rg.Regexp)
-		if err != nil {
-			return RulesTransformed{}, fmt.Errorf("failed to compile regexp %q: %w", rg.Regexp, err)
-		}
-
-		switch rg.Mode {
-		case "allow":
-			regexpAllow = append(regexpAllow, re)
-		case "block":
-			regexpBan = append(regexpBan, re)
-		default:
-			log.Printf("mode %q is not known, the rule %q cannot not be applied", rg.Mode, rg.Regexp)
-		}
-	}
-
-	rules := RulesTransformed{
-		Bantime:        bantime,
-		Findtime:       findtime,
-		URLRegexpAllow: regexpAllow,
-		URLRegexpBan:   regexpBan,
-		MaxRetry:       r.Maxretry,
-		Enabled:        r.Enabled,
-	}
-
-	log.Printf("FailToBan Rules : '%+v'", rules)
-
-	return rules, nil
-}
-
-// Fail2Ban holds the necessary components of a Traefik plugin.
-type Fail2Ban struct {
-	next  http.Handler
-	name  string
-	rules RulesTransformed
-
-	muIP     sync.Mutex
-	ipViewed map[string]ipchecking.IPViewed
 }
 
 // ImportIP extract all ip from config sources.
@@ -169,7 +76,7 @@ func ImportIP(list List) ([]string, error) {
 
 // New instantiates and returns the required components used to handle a HTTP
 // request.
-func New(_ context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
+func New(_ context.Context, next http.Handler, config *Config, _ string) (http.Handler, error) {
 	if !config.Rules.Enabled {
 		log.Println("Plugin: FailToBan is disabled")
 
@@ -218,124 +125,32 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 		return nil, fmt.Errorf("failed to parse blacklist IPs: %w", err)
 	}
 
-	rules, err := TransformRule(config.Rules)
+	rules, err := rules.TransformRule(config.Rules)
 	if err != nil {
 		return nil, fmt.Errorf("error when Transforming rules: %w", err)
 	}
 
-	urlAllow := uAllow.New(rules.URLRegexpAllow)
-
 	log.Println("Plugin: FailToBan is up and running")
 
-	f2b := &Fail2Ban{
-		next:     next,
-		name:     name,
-		rules:    rules,
-		ipViewed: make(map[string]ipchecking.IPViewed),
-	}
+	f2b := fail2ban.New(rules)
 
-	urlDeny := uDeny.New(rules.URLRegexpBan, &f2b.muIP, &f2b.ipViewed)
-
-	return chain.New(
+	c := chain.New(
 		next,
 		denyHandler,
 		allowHandler,
-		urlDeny,
-		urlAllow,
-		f2b,
-	), nil
-}
+		uDeny.New(rules.URLRegexpBan, f2b),
+		uAllow.New(rules.URLRegexpAllow),
+		f2bHandler.New(f2b),
+	)
 
-// ServeHTTP iterates over every headers to match the ones specified in the
-// configuration and return nothing if regexp failed.
-func (u *Fail2Ban) ServeHTTP(rw http.ResponseWriter, req *http.Request) (*chain.Status, error) {
-	data := data.GetData(req)
-	if data == nil {
-		return nil, errors.New("failed to get data from request context")
-	}
-
-	if !u.shouldAllow(data.RemoteIP) {
-		return &chain.Status{Return: true}, nil
-	}
-
-	return nil, nil
-}
-
-// shouldAllow check if the request should be allowed.
-func (u *Fail2Ban) shouldAllow(remoteIP string) bool {
-	u.muIP.Lock()
-	defer u.muIP.Unlock()
-
-	ip, foundIP := u.ipViewed[remoteIP]
-
-	// Fail2Ban
-	if !foundIP {
-		u.ipViewed[remoteIP] = ipchecking.IPViewed{
-			Viewed: time.Now(),
-			Count:  1,
+	if rules.StatusCode != "" {
+		statusCodeHandler, err := status.New(next, rules.StatusCode, f2b)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create status handler: %w", err)
 		}
 
-		LoggerDEBUG.Printf("welcome %q", remoteIP)
-
-		return true
+		c.WithStatus(statusCodeHandler)
 	}
 
-	if ip.Denied {
-		if time.Now().Before(ip.Viewed.Add(u.rules.Bantime)) {
-			u.ipViewed[remoteIP] = ipchecking.IPViewed{
-				Viewed: ip.Viewed,
-				Count:  ip.Count + 1,
-				Denied: true,
-			}
-
-			LoggerDEBUG.Printf("%q is still banned since %q, %d request",
-				remoteIP, ip.Viewed.Format(time.RFC3339), ip.Count+1)
-
-			return false
-		}
-
-		u.ipViewed[remoteIP] = ipchecking.IPViewed{
-			Viewed: time.Now(),
-			Count:  1,
-			Denied: false,
-		}
-
-		LoggerDEBUG.Println(remoteIP + " is no longer banned")
-
-		return true
-	}
-
-	if time.Now().Before(ip.Viewed.Add(u.rules.Findtime)) {
-		if ip.Count+1 >= u.rules.MaxRetry {
-			u.ipViewed[remoteIP] = ipchecking.IPViewed{
-				Viewed: time.Now(),
-				Count:  ip.Count + 1,
-				Denied: true,
-			}
-
-			LoggerDEBUG.Println(remoteIP + " is now banned temporarily")
-
-			return false
-		}
-
-		u.ipViewed[remoteIP] = ipchecking.IPViewed{
-			Viewed: ip.Viewed,
-			Count:  ip.Count + 1,
-			Denied: false,
-		}
-
-		LoggerDEBUG.Printf("welcome back %q for the %d time", remoteIP, ip.Count+1)
-
-		return true
-	}
-
-	u.ipViewed[remoteIP] = ipchecking.IPViewed{
-		Viewed: time.Now(),
-		Count:  1,
-		Denied: false,
-	}
-
-	LoggerDEBUG.Printf("welcome back %q", remoteIP)
-
-	return true
+	return c, nil
 }

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -8,9 +8,14 @@ import (
 	"github.com/tomMoulard/fail2ban/pkg/data"
 )
 
+// Status is a status that can be returned by a handler.
 type Status struct {
+	// Return is a flag that tells the chain to return. If Return is true, the
+	// chain will return a 403 (e.g., the ip is in the denylist)
 	Return bool
-	Break  bool
+	// Break is a flag that tells the chain to break. If Break is true, the chain
+	// will stop (e.g., the ip is in the allowlist)
+	Break bool
 }
 
 // ChainHandler is a handler that can be chained.
@@ -30,6 +35,7 @@ type chain struct {
 	status   *http.Handler
 }
 
+// New creates a new chain.
 func New(final http.Handler, handlers ...ChainHandler) Chain {
 	return &chain{
 		handlers: handlers,
@@ -37,6 +43,7 @@ func New(final http.Handler, handlers ...ChainHandler) Chain {
 	}
 }
 
+// WithStatus sets the status handler.
 func (c *chain) WithStatus(status http.Handler) {
 	c.status = &status
 }

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -4,16 +4,14 @@ package data
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
-	"os"
 
 	logger "github.com/tomMoulard/fail2ban/pkg/log"
 )
 
 // l debug logger. noop by default.
-var l = logger.New(os.Stdout, "DEBUG: data: ", log.Ldate|log.Ltime|log.Lshortfile)
+var l = logger.New("data")
 
 type key string
 

--- a/pkg/fail2ban/fail2ban.go
+++ b/pkg/fail2ban/fail2ban.go
@@ -84,7 +84,8 @@ func (u *Fail2Ban) ShouldAllow(remoteIP string) bool {
 				Denied: true,
 			}
 
-			l.Println(remoteIP + " is now banned temporarily")
+			l.Printf("%q is banned for %d>=%d request",
+				remoteIP, ip.Count+1, u.rules.MaxRetry)
 
 			return false
 		}

--- a/pkg/fail2ban/fail2ban.go
+++ b/pkg/fail2ban/fail2ban.go
@@ -2,8 +2,6 @@
 package fail2ban
 
 import (
-	"log"
-	"os"
 	"sync"
 	"time"
 
@@ -14,7 +12,7 @@ import (
 )
 
 // l debug logger. noop by default.
-var l = logger.New(os.Stdout, "DEBUG: fail2ban: ", log.Ldate|log.Ltime|log.Lshortfile)
+var l = logger.New("fail2ban")
 
 // Fail2Ban is a fail2ban implementation.
 type Fail2Ban struct {

--- a/pkg/fail2ban/fail2ban.go
+++ b/pkg/fail2ban/fail2ban.go
@@ -1,0 +1,112 @@
+// Package fail2ban provides a fail2ban implementation.
+package fail2ban
+
+import (
+	"log"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/tomMoulard/fail2ban/pkg/ipchecking"
+	logger "github.com/tomMoulard/fail2ban/pkg/log"
+	"github.com/tomMoulard/fail2ban/pkg/rules"
+	utime "github.com/tomMoulard/fail2ban/pkg/utils/time"
+)
+
+// l debug logger. noop by default.
+var l = logger.New(os.Stdout, "DEBUG: fail2ban: ", log.Ldate|log.Ltime|log.Lshortfile)
+
+// Fail2Ban is a fail2ban implementation.
+type Fail2Ban struct {
+	rules rules.RulesTransformed
+
+	MuIP sync.Mutex
+	IPs  map[string]ipchecking.IPViewed
+}
+
+// New creates a new Fail2Ban.
+func New(rules rules.RulesTransformed) *Fail2Ban {
+	return &Fail2Ban{
+		rules: rules,
+		IPs:   make(map[string]ipchecking.IPViewed),
+	}
+}
+
+// ShouldAllow check if the request should be allowed.
+func (u *Fail2Ban) ShouldAllow(remoteIP string) bool {
+	u.MuIP.Lock()
+	defer u.MuIP.Unlock()
+
+	ip, foundIP := u.IPs[remoteIP]
+
+	// Fail2Ban
+	if !foundIP {
+		u.IPs[remoteIP] = ipchecking.IPViewed{
+			Viewed: utime.Now(),
+			Count:  1,
+		}
+
+		l.Printf("welcome %q", remoteIP)
+
+		return true
+	}
+
+	if ip.Denied {
+		if utime.Now().Before(ip.Viewed.Add(u.rules.Bantime)) {
+			u.IPs[remoteIP] = ipchecking.IPViewed{
+				Viewed: ip.Viewed,
+				Count:  ip.Count + 1,
+				Denied: true,
+			}
+
+			l.Printf("%q is still banned since %q, %d request",
+				remoteIP, ip.Viewed.Format(time.RFC3339), ip.Count+1)
+
+			return false
+		}
+
+		u.IPs[remoteIP] = ipchecking.IPViewed{
+			Viewed: utime.Now(),
+			Count:  1,
+			Denied: false,
+		}
+
+		l.Println(remoteIP + " is no longer banned")
+
+		return true
+	}
+
+	if utime.Now().Before(ip.Viewed.Add(u.rules.Findtime)) {
+		if ip.Count+1 >= u.rules.MaxRetry {
+			u.IPs[remoteIP] = ipchecking.IPViewed{
+				Viewed: utime.Now(),
+				Count:  ip.Count + 1,
+				Denied: true,
+			}
+
+			l.Println(remoteIP + " is now banned temporarily")
+
+			return false
+		}
+
+		u.IPs[remoteIP] = ipchecking.IPViewed{
+			Viewed: ip.Viewed,
+			Count:  ip.Count + 1,
+			Denied: false,
+		}
+
+		l.Printf("welcome back %q for the %d time", remoteIP, ip.Count+1)
+
+		return true
+	}
+
+	u.IPs[remoteIP] = ipchecking.IPViewed{
+		Viewed: utime.Now(),
+		Count:  1,
+		Denied: false,
+	}
+
+	l.Printf("welcome back %q", remoteIP)
+
+	return true
+}

--- a/pkg/fail2ban/fail2ban_test.go
+++ b/pkg/fail2ban/fail2ban_test.go
@@ -1,0 +1,120 @@
+package fail2ban
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tomMoulard/fail2ban/pkg/ipchecking"
+	"github.com/tomMoulard/fail2ban/pkg/rules"
+	utime "github.com/tomMoulard/fail2ban/pkg/utils/time"
+)
+
+func TestShouldAllow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      *Fail2Ban
+		remoteIP string
+		expect   assert.BoolAssertionFunc
+	}{
+		{
+			name: "first request",
+			cfg: &Fail2Ban{
+				IPs: map[string]ipchecking.IPViewed{},
+			},
+			expect: assert.True,
+		},
+		{
+			name: "second request",
+			cfg: &Fail2Ban{
+				IPs: map[string]ipchecking.IPViewed{
+					"10.0.0.0": {
+						Viewed: utime.Now(),
+						Count:  1,
+					},
+				},
+			},
+			remoteIP: "10.0.0.0",
+			expect:   assert.True,
+		},
+		{
+			name: "denylisted request",
+			cfg: &Fail2Ban{
+				rules: rules.RulesTransformed{
+					Bantime: 300 * time.Second,
+				},
+				IPs: map[string]ipchecking.IPViewed{
+					"10.0.0.0": {
+						Viewed: utime.Now(),
+						Count:  1,
+						Denied: true,
+					},
+				},
+			},
+			remoteIP: "10.0.0.0",
+			expect:   assert.False,
+		},
+		{
+			name: "should unblock request", // since no request during bantime
+			cfg: &Fail2Ban{
+				rules: rules.RulesTransformed{
+					Bantime: 300 * time.Second,
+				},
+				IPs: map[string]ipchecking.IPViewed{
+					"10.0.0.0": {
+						Viewed: utime.Now().Add(-600 * time.Second),
+						Count:  1,
+						Denied: true,
+					},
+				},
+			},
+			remoteIP: "10.0.0.0",
+			expect:   assert.True,
+		},
+		{
+			name: "should block request", // since too much request during findtime
+			cfg: &Fail2Ban{
+				rules: rules.RulesTransformed{
+					MaxRetry: 1,
+					Findtime: 300 * time.Second,
+				},
+				IPs: map[string]ipchecking.IPViewed{
+					"10.0.0.0": {
+						Viewed: utime.Now().Add(600 * time.Second),
+						Count:  1,
+					},
+				},
+			},
+			remoteIP: "10.0.0.0",
+			expect:   assert.False,
+		},
+		{
+			name: "should check request",
+			cfg: &Fail2Ban{
+				rules: rules.RulesTransformed{
+					MaxRetry: 3,
+					Findtime: 300 * time.Second,
+				},
+				IPs: map[string]ipchecking.IPViewed{
+					"10.0.0.0": {
+						Viewed: utime.Now().Add(600 * time.Second),
+						Count:  1,
+					},
+				},
+			},
+			remoteIP: "10.0.0.0",
+			expect:   assert.True,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.cfg.ShouldAllow(test.remoteIP)
+			test.expect(t, got)
+		})
+	}
+}

--- a/pkg/fail2ban/handler/handler.go
+++ b/pkg/fail2ban/handler/handler.go
@@ -1,0 +1,34 @@
+// Package handler provides a fail2ban middleware.
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/tomMoulard/fail2ban/pkg/chain"
+	"github.com/tomMoulard/fail2ban/pkg/data"
+	"github.com/tomMoulard/fail2ban/pkg/fail2ban"
+)
+
+type handler struct {
+	f2b *fail2ban.Fail2Ban
+}
+
+func New(f2b *fail2ban.Fail2Ban) *handler {
+	return &handler{f2b: f2b}
+}
+
+// ServeHTTP iterates over every headers to match the ones specified in the
+// configuration and return nothing if regexp failed.
+func (h *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) (*chain.Status, error) {
+	data := data.GetData(req)
+	if data == nil {
+		return nil, errors.New("failed to get data from request context")
+	}
+
+	if !h.f2b.ShouldAllow(data.RemoteIP) {
+		return &chain.Status{Return: true}, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/list/allow/allow.go
+++ b/pkg/list/allow/allow.go
@@ -4,9 +4,7 @@ package allow
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
-	"os"
 
 	"github.com/tomMoulard/fail2ban/pkg/chain"
 	"github.com/tomMoulard/fail2ban/pkg/data"
@@ -15,7 +13,7 @@ import (
 )
 
 // l debug logger. noop by default.
-var l = logger.New(os.Stdout, "DEBUG: list allow: ", log.Ldate|log.Ltime|log.Lshortfile)
+var l = logger.New("list allow")
 
 type allow struct {
 	list ipchecking.NetIPs

--- a/pkg/list/deny/deny.go
+++ b/pkg/list/deny/deny.go
@@ -4,9 +4,7 @@ package deny
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
-	"os"
 
 	"github.com/tomMoulard/fail2ban/pkg/chain"
 	"github.com/tomMoulard/fail2ban/pkg/data"
@@ -15,7 +13,7 @@ import (
 )
 
 // l debug logger. noop by default.
-var l = logger.New(os.Stdout, "DEBUG: list deny: ", log.Ldate|log.Ltime|log.Lshortfile)
+var l = logger.New("list deny")
 
 type deny struct {
 	list ipchecking.NetIPs

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,11 +1,10 @@
-//go:build !DEBUG
+//go:build DEBUG
 
 // Package log contains the logger mechanism for the plugin.
 // Noop logger for non-debug builds.
 package log
 
 import (
-	"io"
 	"log"
 )
 
@@ -13,7 +12,7 @@ type Logger struct {
 	*log.Logger
 }
 
-func New(out io.Writer, prefix string, flag int) Logger {
+func New(string) Logger {
 	return Logger{}
 }
 

--- a/pkg/log/log_debug.go
+++ b/pkg/log/log_debug.go
@@ -1,18 +1,18 @@
-//go:build DEBUG
+//go:build !DEBUG
 
 // Package log contains the logger mechanism for the plugin.
 // Debug logger for debug builds.
 package log
 
 import (
-	"io"
 	"log"
+	"os"
 )
 
 type Logger struct {
 	*log.Logger
 }
 
-func New(out io.Writer, prefix string, flag int) Logger {
-	return Logger{log.New(out, prefix, flag)}
+func New(prefix string) Logger {
+	return Logger{log.New(os.Stdout, prefix+": ", log.Ldate|log.Ltime|log.Lshortfile)}
 }

--- a/pkg/response/status/code_catcher.go
+++ b/pkg/response/status/code_catcher.go
@@ -1,0 +1,148 @@
+package status
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// Source: https://github.com/traefik/traefik/blob/05d2c86074a21d482945b9994d85e3b66de0480d/pkg/middlewares/customerrors/custom_errors.go
+
+// codeCatcher is a response writer that detects as soon as possible
+// whether the response is a code within the ranges of codes it watches for.
+// If it is, it simply drops the data from the response.
+// Otherwise, it forwards it directly to the original client (its responseWriter) without any buffering.
+type codeCatcher struct {
+	headerMap          http.Header
+	code               int
+	httpCodeRanges     HTTPCodeRanges
+	caughtFilteredCode bool
+	responseWriter     http.ResponseWriter
+	headersSent        bool
+}
+
+func newCodeCatcher(rw http.ResponseWriter, httpCodeRanges HTTPCodeRanges) *codeCatcher {
+	return &codeCatcher{
+		headerMap:      make(http.Header),
+		code:           http.StatusOK, // If backend does not call WriteHeader on us, we consider it's a 200.
+		responseWriter: rw,
+		httpCodeRanges: httpCodeRanges,
+	}
+}
+
+func (cc *codeCatcher) Header() http.Header {
+	if cc.headersSent {
+		return cc.responseWriter.Header()
+	}
+
+	if cc.headerMap == nil {
+		cc.headerMap = make(http.Header)
+	}
+
+	return cc.headerMap
+}
+
+func (cc *codeCatcher) getCode() int {
+	return cc.code
+}
+
+// isFilteredCode returns whether the codeCatcher received a response code among the ones it is watching,
+// and for which the response should be deferred to the fail2ban handler.
+func (cc *codeCatcher) isFilteredCode() bool {
+	return cc.caughtFilteredCode
+}
+
+func (cc *codeCatcher) Write(buf []byte) (int, error) {
+	// If WriteHeader was already called from the caller, this is a NOOP.
+	// Otherwise, cc.code is actually a 200 here.
+	cc.WriteHeader(cc.code)
+
+	if cc.caughtFilteredCode {
+		// We don't care about the contents of the response,
+		// since we want to serve the ones from the error page,
+		// so we just drop them.
+		return len(buf), nil
+	}
+
+	i, err := cc.responseWriter.Write(buf)
+	if err != nil {
+		return i, fmt.Errorf("failed to write to response: %w", err)
+	}
+
+	return i, nil
+}
+
+// WriteHeader is, in the specific case of 1xx status codes, a direct call to the wrapped ResponseWriter, without marking headers as sent,
+// allowing so further calls.
+func (cc *codeCatcher) WriteHeader(code int) {
+	if cc.headersSent || cc.caughtFilteredCode {
+		return
+	}
+
+	// Handling informational headers.
+	if code >= 100 && code <= 199 {
+		// Multiple informational status codes can be used,
+		// so here the copy is not appending the values to not repeat them.
+		for k, v := range cc.Header() {
+			cc.responseWriter.Header()[k] = v
+		}
+
+		cc.responseWriter.WriteHeader(code)
+
+		return
+	}
+
+	cc.code = code
+	for _, block := range cc.httpCodeRanges {
+		if cc.code >= block[0] && cc.code <= block[1] {
+			cc.caughtFilteredCode = true
+			// it will be up to the caller to send the headers,
+			// so it is out of our hands now.
+			return
+		}
+	}
+
+	// The copy is not appending the values,
+	// to not repeat them in case any informational status code has been written.
+	for k, v := range cc.Header() {
+		cc.responseWriter.Header()[k] = v
+	}
+
+	cc.responseWriter.WriteHeader(cc.code)
+	cc.headersSent = true
+}
+
+// Hijack hijacks the connection.
+func (cc *codeCatcher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := cc.responseWriter.(http.Hijacker); ok {
+		conn, rw, err := hj.Hijack()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to hijack connection: %w", err)
+		}
+
+		return conn, rw, nil
+	}
+
+	return nil, nil, fmt.Errorf("%T is not a http.Hijacker", cc.responseWriter)
+}
+
+// Flush sends any buffered data to the client.
+func (cc *codeCatcher) Flush() {
+	// If WriteHeader was already called from the caller, this is a NOOP.
+	// Otherwise, cc.code is actually a 200 here.
+	cc.WriteHeader(cc.code)
+
+	// We don't care about the contents of the response,
+	// since we want to serve the ones from the error page,
+	// so we just don't flush.
+	// (e.g., To prevent superfluous WriteHeader on request with a
+	// `Transfert-Encoding: chunked` header).
+	if cc.caughtFilteredCode {
+		return
+	}
+
+	if flusher, ok := cc.responseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}

--- a/pkg/response/status/http_code_range.go
+++ b/pkg/response/status/http_code_range.go
@@ -1,0 +1,49 @@
+package status
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// Source: https://github.com/traefik/traefik/blob/05d2c86074a21d482945b9994d85e3b66de0480d/pkg/types/http_code_range.go
+
+// HTTPCodeRanges holds HTTP code ranges.
+type HTTPCodeRanges [][2]int
+
+// NewHTTPCodeRanges creates HTTPCodeRanges from a given []string.
+// Break out the http status code ranges into a low int and high int
+// for ease of use at runtime.
+func NewHTTPCodeRanges(strBlocks []string) (HTTPCodeRanges, error) {
+	blocks := make(HTTPCodeRanges, 0, len(strBlocks))
+
+	for _, block := range strBlocks {
+		codes := strings.Split(block, "-")
+		// if only a single HTTP code was configured, assume the best and create the correct configuration on the user's behalf
+		if len(codes) == 1 {
+			codes = append(codes, codes[0])
+		}
+
+		lowCode, err := strconv.Atoi(codes[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse HTTP code: %w", err)
+		}
+
+		highCode, err := strconv.Atoi(codes[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse HTTP code: %w", err)
+		}
+
+		blocks = append(blocks, [2]int{lowCode, highCode})
+	}
+
+	return blocks, nil
+}
+
+// Contains tests whether the passed status code is within one of its HTTP code ranges.
+func (h HTTPCodeRanges) Contains(statusCode int) bool {
+	return slices.ContainsFunc(h, func(block [2]int) bool {
+		return statusCode >= block[0] && statusCode <= block[1]
+	})
+}

--- a/pkg/response/status/status.go
+++ b/pkg/response/status/status.go
@@ -3,9 +3,7 @@ package status
 
 import (
 	"fmt"
-	"log"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/tomMoulard/fail2ban/pkg/data"
@@ -14,7 +12,7 @@ import (
 )
 
 // l debug logger. noop by default.
-var l = logger.New(os.Stdout, "DEBUG: status: ", log.Ldate|log.Ltime|log.Lshortfile)
+var l = logger.New("status")
 
 type status struct {
 	next       http.Handler
@@ -36,9 +34,11 @@ func New(next http.Handler, statusCode string, f2b *fail2ban.Fail2Ban) (*status,
 }
 
 func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	l.Printf("status handler")
+
 	data := data.GetData(r)
 	if data == nil {
-		l.Println("data is nil")
+		l.Print("data is nil")
 
 		return
 	}

--- a/pkg/response/status/status.go
+++ b/pkg/response/status/status.go
@@ -1,0 +1,59 @@
+// Package status is a middleware that denies requests from the status of the answer
+package status
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/tomMoulard/fail2ban/pkg/data"
+	"github.com/tomMoulard/fail2ban/pkg/fail2ban"
+	logger "github.com/tomMoulard/fail2ban/pkg/log"
+)
+
+// l debug logger. noop by default.
+var l = logger.New(os.Stdout, "DEBUG: status: ", log.Ldate|log.Ltime|log.Lshortfile)
+
+type status struct {
+	next       http.Handler
+	codeRanges HTTPCodeRanges
+	f2b        *fail2ban.Fail2Ban
+}
+
+func New(next http.Handler, statusCode string, f2b *fail2ban.Fail2Ban) (*status, error) {
+	codeRanges, err := NewHTTPCodeRanges(strings.Split(statusCode, ","))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP code ranges: %w", err)
+	}
+
+	return &status{
+		next:       next,
+		codeRanges: codeRanges,
+		f2b:        f2b,
+	}, nil
+}
+
+func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	data := data.GetData(r)
+	if data == nil {
+		l.Println("data is nil")
+
+		return
+	}
+
+	l.Printf("data: %+v", data)
+
+	catcher := newCodeCatcher(w, s.codeRanges)
+	s.next.ServeHTTP(catcher, r)
+	w.WriteHeader(catcher.getCode())
+
+	l.Printf("catcher: %+v", *catcher)
+
+	if !catcher.isFilteredCode() {
+		return
+	}
+
+	s.f2b.ShouldAllow(data.RemoteIP)
+}

--- a/pkg/response/status/status_test.go
+++ b/pkg/response/status/status_test.go
@@ -101,12 +101,12 @@ func TestStatus(t *testing.T) {
 			t.Parallel()
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.NotZero(t, test.respStatusCode)
+				assert.NotZero(t, test.respStatusCode)
 				w.WriteHeader(test.respStatusCode)
 				t.Logf("status code: %d", test.respStatusCode)
 
 				_, err := w.Write([]byte(body))
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			})
 
 			f2b := fail2ban.New(rules.RulesTransformed{

--- a/pkg/response/status/status_test.go
+++ b/pkg/response/status/status_test.go
@@ -1,0 +1,123 @@
+package status
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tomMoulard/fail2ban/pkg/data"
+	"github.com/tomMoulard/fail2ban/pkg/fail2ban"
+	"github.com/tomMoulard/fail2ban/pkg/ipchecking"
+	"github.com/tomMoulard/fail2ban/pkg/rules"
+	utime "github.com/tomMoulard/fail2ban/pkg/utils/time"
+)
+
+func TestStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		codeRanges       string
+		statusCode       int
+		ips              map[string]ipchecking.IPViewed
+		expectedStatus   int
+		expectedIPViewed map[string]ipchecking.IPViewed
+	}{
+		{
+			name:       "already denied", // should not happen
+			codeRanges: "400-499",
+			statusCode: http.StatusBadRequest,
+			ips: map[string]ipchecking.IPViewed{
+				"192.0.2.1": {
+					Viewed: utime.Now(),
+					Count:  42,
+					Denied: true,
+				},
+			},
+			expectedIPViewed: map[string]ipchecking.IPViewed{
+				"192.0.2.1": {
+					Viewed: utime.Now(),
+					Count:  43,
+					Denied: true,
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "denied next time",
+			codeRanges: "400-499",
+			statusCode: http.StatusBadRequest,
+			ips: map[string]ipchecking.IPViewed{
+				"192.0.2.1": {
+					Viewed: utime.Now(),
+					Count:  42,
+				},
+			},
+			expectedIPViewed: map[string]ipchecking.IPViewed{
+				"192.0.2.1": {
+					Viewed: utime.Now(),
+					Count:  43,
+					Denied: true,
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "not denied in limits",
+			codeRanges: "400-499",
+			statusCode: http.StatusBadRequest,
+			ips:        map[string]ipchecking.IPViewed{},
+			expectedIPViewed: map[string]ipchecking.IPViewed{
+				"192.0.2.1": {
+					Viewed: utime.Now(),
+					Count:  1,
+					Denied: false,
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:             "not denied",
+			codeRanges:       "400-499",
+			statusCode:       http.StatusOK,
+			ips:              map[string]ipchecking.IPViewed{},
+			expectedIPViewed: map[string]ipchecking.IPViewed{},
+			expectedStatus:   http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NotZero(t, test.statusCode)
+				w.WriteHeader(test.statusCode)
+				t.Logf("status code: %d", test.statusCode)
+			})
+
+			f2b := fail2ban.New(rules.RulesTransformed{
+				MaxRetry: 1,
+				Findtime: 300 * time.Second,
+				Bantime:  300 * time.Second,
+			})
+			f2b.IPs = test.ips
+			d, err := New(next, test.codeRanges, f2b)
+			require.NoError(t, err)
+
+			recorder := &httptest.ResponseRecorder{}
+			req := httptest.NewRequest(http.MethodGet, "https://example.com/foo", nil)
+			req, err = data.ServeHTTP(recorder, req)
+			require.NoError(t, err)
+
+			d.ServeHTTP(recorder, req)
+			t.Logf("recorder: %+v", recorder)
+
+			assert.Equal(t, test.expectedIPViewed, f2b.IPs)
+			assert.Equal(t, test.expectedStatus, recorder.Code)
+		})
+	}
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -1,0 +1,81 @@
+// Package rules contains the rules for the fail2ban plugin.
+package rules
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+)
+
+// Urlregexp struct.
+type Urlregexp struct {
+	Regexp string `yaml:"regexp"`
+	Mode   string `yaml:"mode"`
+}
+
+// Rules struct fail2ban config.
+type Rules struct {
+	Bantime    string      `yaml:"bantime"`  // exprimate in a smart way: 3m
+	Enabled    bool        `yaml:"enabled"`  // enable or disable the jail
+	Findtime   string      `yaml:"findtime"` // exprimate in a smart way: 3m
+	Maxretry   int         `yaml:"maxretry"`
+	Urlregexps []Urlregexp `yaml:"urlregexps"`
+	StatusCode string      `yaml:"statuscode"`
+}
+
+// RulesTransformed transformed Rules struct.
+type RulesTransformed struct {
+	Bantime        time.Duration
+	Findtime       time.Duration
+	URLRegexpAllow []*regexp.Regexp
+	URLRegexpBan   []*regexp.Regexp
+	MaxRetry       int
+	Enabled        bool
+	StatusCode     string
+}
+
+// TransformRule morph a Rules object into a RulesTransformed.
+func TransformRule(r Rules) (RulesTransformed, error) {
+	bantime, err := time.ParseDuration(r.Bantime)
+	if err != nil {
+		return RulesTransformed{}, fmt.Errorf("failed to parse bantime duration: %w", err)
+	}
+
+	findtime, err := time.ParseDuration(r.Findtime)
+	if err != nil {
+		return RulesTransformed{}, fmt.Errorf("failed to parse findtime duration: %w", err)
+	}
+
+	var regexpAllow []*regexp.Regexp
+
+	var regexpBan []*regexp.Regexp
+
+	for _, rg := range r.Urlregexps {
+		re, err := regexp.Compile(rg.Regexp)
+		if err != nil {
+			return RulesTransformed{}, fmt.Errorf("failed to compile regexp %q: %w", rg.Regexp, err)
+		}
+
+		switch rg.Mode {
+		case "allow":
+			regexpAllow = append(regexpAllow, re)
+		case "block":
+			regexpBan = append(regexpBan, re)
+		default:
+			log.Printf("mode %q is not known, the rule %q cannot not be applied", rg.Mode, rg.Regexp)
+		}
+	}
+
+	rules := RulesTransformed{
+		Bantime:        bantime,
+		Findtime:       findtime,
+		URLRegexpAllow: regexpAllow,
+		URLRegexpBan:   regexpBan,
+		MaxRetry:       r.Maxretry,
+		Enabled:        r.Enabled,
+		StatusCode:     r.StatusCode,
+	}
+
+	return rules, nil
+}

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -1,0 +1,40 @@
+package rules
+
+import "testing"
+
+func TestTransformRules(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		send   Rules
+		expect RulesTransformed
+		err    error
+	}{
+		{
+			name: "dummy",
+			send: Rules{
+				Bantime:  "300s",
+				Findtime: "120s",
+				Enabled:  true,
+			},
+			expect: RulesTransformed{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, e := TransformRule(test.send)
+			if e != nil && (test.err == nil || e.Error() != test.err.Error()) {
+				t.Errorf("TransformRule_err: wanted %q got %q",
+					test.err, e)
+			}
+
+			if test.expect.Bantime == got.Bantime {
+				t.Errorf("TransformRule: wanted '%+v' got '%+v'",
+					test.expect, got)
+			}
+		})
+	}
+}

--- a/pkg/url/allow/allow.go
+++ b/pkg/url/allow/allow.go
@@ -2,9 +2,7 @@
 package allow
 
 import (
-	"log"
 	"net/http"
-	"os"
 	"regexp"
 
 	"github.com/tomMoulard/fail2ban/pkg/chain"
@@ -12,7 +10,7 @@ import (
 )
 
 // l debug logger. noop by default.
-var l = logger.New(os.Stdout, "DEBUG: url allow: ", log.Ldate|log.Ltime|log.Lshortfile)
+var l = logger.New("url allow")
 
 type allow struct {
 	regs []*regexp.Regexp

--- a/pkg/url/deny/deny.go
+++ b/pkg/url/deny/deny.go
@@ -3,9 +3,7 @@ package deny
 
 import (
 	"errors"
-	"log"
 	"net/http"
-	"os"
 	"regexp"
 
 	"github.com/tomMoulard/fail2ban/pkg/chain"
@@ -17,7 +15,7 @@ import (
 )
 
 // l debug logger. noop by default.
-var l = logger.New(os.Stdout, "DEBUG: url deny: ", log.Ldate|log.Ltime|log.Lshortfile)
+var l = logger.New("url deny")
 
 type deny struct {
 	regs []*regexp.Regexp

--- a/pkg/url/deny/deny.go
+++ b/pkg/url/deny/deny.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"os"
 	"regexp"
-	"sync"
 
 	"github.com/tomMoulard/fail2ban/pkg/chain"
 	"github.com/tomMoulard/fail2ban/pkg/data"
+	"github.com/tomMoulard/fail2ban/pkg/fail2ban"
 	"github.com/tomMoulard/fail2ban/pkg/ipchecking"
 	logger "github.com/tomMoulard/fail2ban/pkg/log"
 	"github.com/tomMoulard/fail2ban/pkg/utils/time"
@@ -22,15 +22,13 @@ var l = logger.New(os.Stdout, "DEBUG: url deny: ", log.Ldate|log.Ltime|log.Lshor
 type deny struct {
 	regs []*regexp.Regexp
 
-	muIP     *sync.Mutex
-	ipViewed *map[string]ipchecking.IPViewed
+	f2b *fail2ban.Fail2Ban
 }
 
-func New(regs []*regexp.Regexp, muIP *sync.Mutex, ipViewed *map[string]ipchecking.IPViewed) *deny {
+func New(regs []*regexp.Regexp, f2b *fail2ban.Fail2Ban) *deny {
 	return &deny{
-		regs:     regs,
-		muIP:     muIP,
-		ipViewed: ipViewed,
+		regs: regs,
+		f2b:  f2b,
 	}
 }
 
@@ -42,14 +40,14 @@ func (d *deny) ServeHTTP(w http.ResponseWriter, r *http.Request) (*chain.Status,
 
 	l.Printf("data: %+v", data)
 
-	d.muIP.Lock()
-	defer d.muIP.Unlock()
+	d.f2b.MuIP.Lock()
+	defer d.f2b.MuIP.Unlock()
 
-	ip := (*d.ipViewed)[data.RemoteIP]
+	ip := d.f2b.IPs[data.RemoteIP]
 
 	for _, reg := range d.regs {
 		if reg.MatchString(r.URL.String()) {
-			(*d.ipViewed)[data.RemoteIP] = ipchecking.IPViewed{
+			d.f2b.IPs[data.RemoteIP] = ipchecking.IPViewed{
 				Viewed: time.Now(),
 				Count:  ip.Count + 1,
 				Denied: true,


### PR DESCRIPTION
This PR adds the status handler that let the plugin check the status code of the request.
As the requests has been already forwarded, the next request will be blocked.
Note that using this implementation, we could simply change the codecatcher implementation to block the request to reach the end user entirely.

This PR fixes #69, #46
