### PR TITLE
fix: remove slices usage from status handler

### DIFF
--- a/pkg/response/status/http_code_range.go
+++ b/pkg/response/status/http_code_range.go
@@ -2,7 +2,6 @@ package status
 
 import (
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 )
@@ -43,7 +42,11 @@ func NewHTTPCodeRanges(strBlocks []string) (HTTPCodeRanges, error) {
 
 // Contains tests whether the passed status code is within one of its HTTP code ranges.
 func (h HTTPCodeRanges) Contains(statusCode int) bool {
-	return slices.ContainsFunc(h, func(block [2]int) bool {
-		return statusCode >= block[0] && statusCode <= block[1]
-	})
+	for ranges := range h {
+		if statusCode >= h[ranges][0] && statusCode <= h[ranges][1] {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/response/status/http_code_range_test.go
+++ b/pkg/response/status/http_code_range_test.go
@@ -1,0 +1,51 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContains(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		ranges     HTTPCodeRanges
+		statusCode int
+		expected   assert.BoolAssertionFunc
+	}{
+		{
+			name:       "empty",
+			ranges:     HTTPCodeRanges{},
+			statusCode: 200,
+			expected:   assert.False,
+		},
+		{
+			name:       "single",
+			ranges:     HTTPCodeRanges{{200, 200}},
+			statusCode: 200,
+			expected:   assert.True,
+		},
+		{
+			name:       "single out of range high",
+			ranges:     HTTPCodeRanges{{200, 200}},
+			statusCode: 201,
+			expected:   assert.False,
+		},
+		{
+			name:       "single out of range low",
+			ranges:     HTTPCodeRanges{{200, 200}},
+			statusCode: 199,
+			expected:   assert.False,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			test.expected(t, test.ranges.Contains(test.statusCode))
+		})
+	}
+}


### PR DESCRIPTION
This PR removes the usage of the `slices` package to fix #120.