### PR TITLE
chore: enalbing logger temporarily

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -6,14 +6,15 @@ package log
 
 import (
 	"log"
+	"os"
 )
 
 type Logger struct {
 	*log.Logger
 }
 
-func New(string) Logger {
-	return Logger{}
+func New(prefix string) Logger {
+	return Logger{log.New(os.Stdout, prefix+": ", log.Ldate|log.Ltime|log.Lshortfile)}
 }
 
 func (l Logger) Printf(format string, v ...interface{}) {}

--- a/pkg/log/log_debug.go
+++ b/pkg/log/log_debug.go
@@ -6,13 +6,16 @@ package log
 
 import (
 	"log"
-	"os"
 )
 
 type Logger struct {
 	*log.Logger
 }
 
-func New(prefix string) Logger {
-	return Logger{log.New(os.Stdout, prefix+": ", log.Ldate|log.Ltime|log.Lshortfile)}
+func New(string) Logger {
+	return Logger{}
 }
+
+func (l Logger) Printf(format string, v ...interface{}) {}
+
+func (l Logger) Println(v ...interface{}) {}


### PR DESCRIPTION
This PR enablees by default the debug logger. This would allow users to test their own confguration, and have data about how the plugin is working on their ends.
