### PR TITLE
feat: convert status handler to match existing handlers

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -80,11 +80,5 @@ func (c *chain) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if c.status != nil {
-		(*c.status).ServeHTTP(w, r)
-
-		return
-	}
-
 	c.final.ServeHTTP(w, r)
 }


### PR DESCRIPTION
Hi,

I recently found your plugin and thought it would be useful to easily secure one of my websites against bruteforce attacks.

While trying it, I noticed that no matter what configuration I put in terms of status codes, I was always getting 403-ed when hitting the `maxretry` limit. I think #136 relates to my issue.

Instead of complaining and adding noise to the issue, I thought it would be more interesting to submit a fix :)

What I did is :

* Converting the status handler to the format used by the others (returning `(*chain.Status, error)`)
* Adding the handler if the status configuration is there, otherwise only adding the rest (this can change, I wasn't sure of this implementation, I think the handler could always be inserted and simply do nothing if no status codes are given in the configuration)
* If the status code is allowed, break the chain

Go is clearly not in my field of expertise so please feel free to give implementation advice.

Thanks in advance for your review !