### PR TITLE
fix: remove tools dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,6 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Maintain dependencies for build tools
-  - package-ecosystem: "gomod"
-    directory: "/tools"
-    schedule:
-      interval: "weekly"
-
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This MR removes the dependabot checks on the tools/ folder thanks to go1.24 !
It follows #191 that upgraded go to go1.24