### PR TITLE
chore: remove yaegi as a go tool, use a pinned version instead

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,6 @@ on:
   push:
   pull_request:
 
-env:
-  GO_VERSION: '1.24'
-
 jobs:
 
   main:
@@ -15,14 +12,12 @@ jobs:
 
     steps:
       # https://github.com/marketplace/actions/checkout
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       # https://github.com/marketplace/actions/setup-go-environment
-      - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: stable
 
       - name: Lint and Tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,7 @@ jobs:
         with:
           go-version: 'stable'
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -32,8 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload dist
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 .PHONY: yaegi_test
 YAEGI_TEST_ARGS ?= -v
 yaegi_test: vendor
-	go tool yaegi test ${YAEGI_TEST_ARGS} .
+	go run github.com/traefik/yaegi/cmd/yaegi@v0.16.1 test ${YAEGI_TEST_ARGS} .
 
 .PHONY: entr
 # https://github.com/eradman/entr

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ tool (
 	github.com/golangci/golangci-lint/cmd/golangci-lint
 	github.com/golangci/misspell/cmd/misspell
 	github.com/goreleaser/goreleaser/v2
-	github.com/traefik/yaegi/cmd/yaegi
 	golang.org/x/vuln/cmd/govulncheck
 )
 
@@ -412,7 +411,6 @@ require (
 	github.com/tomarrell/wrapcheck/v2 v2.10.0 // indirect
 	github.com/tommy-muehle/go-mnd/v2 v2.5.1 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
-	github.com/traefik/yaegi v0.16.1 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/ultraware/funlen v0.2.0 // indirect
 	github.com/ultraware/whitespace v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1043,8 +1043,6 @@ github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+
 github.com/tommy-muehle/go-mnd/v2 v2.5.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
-github.com/traefik/yaegi v0.16.1 h1:f1De3DVJqIDKmnasUF6MwmWv1dSEEat0wcpXhD2On3E=
-github.com/traefik/yaegi v0.16.1/go.mod h1:4eVhbPb3LnD2VigQjhYbEJ69vDRFdT2HQNrXx8eEwUY=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ultraware/funlen v0.2.0 h1:gCHmCn+d2/1SemTdYMiKLAHFYxTYz7z9VIDRaTGyLkI=


### PR DESCRIPTION
This PR removes the direct dependancy to yaegi in the go md as a go tool.
Now, the makefile uses a pinned version of yaegi to run using go run directly.

See https://github.com/traefik/piceus/blob/e7696a97cba8648703f4625595f923ea5ac4f192/pkg/core/yaegi.go#L235

Fix #197
