### PR TITLE
Copy headers for non filtered and allowed requests

### DIFF
--- a/pkg/response/status/status.go
+++ b/pkg/response/status/status.go
@@ -46,15 +46,15 @@ func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Printf("catcher: %+v", *catcher)
 
-	if !catcher.isFilteredCode() { // if this is not a status code of concern: Return and do not increment fail counter.
-		for k, v := range catcher.Header() {
-			w.Header()[k] = v
-		}
+    if !catcher.isFilteredCode() { // if this is not a status code of concern: Return and do not increment fail counter.
+        for k, vv := range catcher.Header() {
+            w.Header().Set(k, strings.Join(vv, ", "))
+        }
 
-		w.WriteHeader(catcher.getCode())
+        w.WriteHeader(catcher.getCode())
 
-		return
-	}
+        return
+    }
 
 	catcher.allowedRequest = s.f2b.ShouldAllow(data.RemoteIP)
 	if !catcher.allowedRequest {
@@ -66,9 +66,9 @@ func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Printf("IP %s is allowed", data.RemoteIP)
 
-	for k, v := range catcher.Header() {
-		w.Header()[k] = v
-	}
+    for k, vv := range catcher.Header() {
+        w.Header().Set(k, strings.Join(vv, ", "))
+    }
 
 	w.WriteHeader(catcher.getCode())
 

--- a/pkg/response/status/status.go
+++ b/pkg/response/status/status.go
@@ -47,6 +47,10 @@ func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("catcher: %+v", *catcher)
 
 	if !catcher.isFilteredCode() { // if this is not a status code of concern: Return and do not increment fail counter.
+		// Copy headers from backend response
+		for k, v := range catcher.Header() {
+			w.Header()[k] = v
+		}
 		w.WriteHeader(catcher.getCode())
 
 		return
@@ -61,6 +65,9 @@ func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fmt.Printf("IP %s is allowed", data.RemoteIP)
+	for k, v := range catcher.Header() {
+		w.Header()[k] = v
+	}
 	w.WriteHeader(catcher.getCode())
 
 	if _, err := w.Write(catcher.bytes); err != nil {

--- a/pkg/response/status/status.go
+++ b/pkg/response/status/status.go
@@ -46,15 +46,15 @@ func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Printf("catcher: %+v", *catcher)
 
-    if !catcher.isFilteredCode() { // if this is not a status code of concern: Return and do not increment fail counter.
-        for k, vv := range catcher.Header() {
-            w.Header().Set(k, strings.Join(vv, ", "))
-        }
+	if !catcher.isFilteredCode() { // if this is not a status code of concern: Return and do not increment fail counter.
+		for k, vv := range catcher.Header() {
+			w.Header().Set(k, strings.Join(vv, ", "))
+		}
 
-        w.WriteHeader(catcher.getCode())
+		w.WriteHeader(catcher.getCode())
 
-        return
-    }
+		return
+	}
 
 	catcher.allowedRequest = s.f2b.ShouldAllow(data.RemoteIP)
 	if !catcher.allowedRequest {
@@ -66,9 +66,9 @@ func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Printf("IP %s is allowed", data.RemoteIP)
 
-    for k, vv := range catcher.Header() {
-        w.Header().Set(k, strings.Join(vv, ", "))
-    }
+	for k, vv := range catcher.Header() {
+		w.Header().Set(k, strings.Join(vv, ", "))
+	}
 
 	w.WriteHeader(catcher.getCode())
 

--- a/pkg/response/status/status.go
+++ b/pkg/response/status/status.go
@@ -47,10 +47,10 @@ func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("catcher: %+v", *catcher)
 
 	if !catcher.isFilteredCode() { // if this is not a status code of concern: Return and do not increment fail counter.
-		// Copy headers from backend response
 		for k, v := range catcher.Header() {
 			w.Header()[k] = v
 		}
+
 		w.WriteHeader(catcher.getCode())
 
 		return
@@ -65,9 +65,11 @@ func (s *status) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fmt.Printf("IP %s is allowed", data.RemoteIP)
+
 	for k, v := range catcher.Header() {
 		w.Header()[k] = v
 	}
+
 	w.WriteHeader(catcher.getCode())
 
 	if _, err := w.Write(catcher.bytes); err != nil {

--- a/pkg/response/status/status_test.go
+++ b/pkg/response/status/status_test.go
@@ -145,3 +145,120 @@ func TestStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestHeaderCopying(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		codeRanges     string
+		respStatusCode int
+		respHeaders    map[string]string
+		shouldCopy     bool
+		remoteIP       string
+		ips            map[string]ipchecking.IPViewed
+	}{
+		{
+			name:           "headers copied for non-filtered status",
+			codeRanges:     "400-499",
+			respStatusCode: http.StatusOK,
+			respHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  "*",
+				"Access-Control-Allow-Methods": "GET, POST",
+				"Content-Type":                 "application/json",
+				"X-Custom-Header":              "test-value",
+			},
+			shouldCopy: true,
+			remoteIP:   "192.0.2.1",
+			ips:        map[string]ipchecking.IPViewed{},
+		},
+		{
+			name:           "headers copied for filtered but allowed status",
+			codeRanges:     "400-499",
+			respStatusCode: http.StatusBadRequest,
+			respHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  "*",
+				"Access-Control-Allow-Methods": "GET, POST",
+				"Content-Type":                 "application/json",
+			},
+			shouldCopy: true,
+			remoteIP:   "192.0.2.1",
+			ips:        map[string]ipchecking.IPViewed{},
+		},
+		{
+			name:           "headers not copied for banned IP",
+			codeRanges:     "400-499",
+			respStatusCode: http.StatusBadRequest,
+			respHeaders: map[string]string{
+				"Access-Control-Allow-Origin":  "*",
+				"Access-Control-Allow-Methods": "GET, POST",
+				"Content-Type":                 "application/json",
+			},
+			shouldCopy: false,
+			remoteIP:   "192.0.2.1",
+			ips: map[string]ipchecking.IPViewed{
+				"192.0.2.1": {
+					Viewed: utime.Now(),
+					Count:  42,
+					Denied: true,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create a test handler that returns specific headers
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for k, v := range test.respHeaders {
+					w.Header().Set(k, v)
+				}
+				w.WriteHeader(test.respStatusCode)
+				_, _ = w.Write([]byte("test body"))
+			})
+
+			rulesObj := rules.Rules{
+				Maxretry:   42,
+				StatusCode: test.codeRanges,
+				Bantime:    "300s",
+				Findtime:   "120s",
+				Enabled:    true,
+			}
+			rulesTransformed, err := rules.TransformRule(rulesObj)
+			require.NoError(t, err)
+
+			f2b := fail2ban.New(rulesTransformed)
+			// Set IP viewed state
+			for ip, viewed := range test.ips {
+				f2b.IPs[ip] = viewed
+			}
+
+			statusHandler, err := New(next, test.codeRanges, f2b)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req, err = data.ServeHTTP(httptest.NewRecorder(), req)
+			require.NoError(t, err)
+
+			d := data.GetData(req)
+			d.RemoteIP = test.remoteIP
+
+			recorder := httptest.NewRecorder()
+			statusHandler.ServeHTTP(recorder, req)
+
+			// Check if headers were copied as expected
+			if test.shouldCopy {
+				for k, v := range test.respHeaders {
+					assert.Equal(t, v, recorder.Header().Get(k), "Header %s should be copied", k)
+				}
+			} else {
+				// For banned IPs, headers should not be copied
+				for k := range test.respHeaders {
+					assert.Empty(t, recorder.Header().Get(k), "Header %s should not be copied for banned IP", k)
+				}
+			}
+		})
+	}
+}

--- a/pkg/response/status/status_test.go
+++ b/pkg/response/status/status_test.go
@@ -215,6 +215,7 @@ func TestHeaderCopying(t *testing.T) {
 				for k, v := range test.respHeaders {
 					w.Header().Set(k, v)
 				}
+
 				w.WriteHeader(test.respStatusCode)
 				_, _ = w.Write([]byte("test body"))
 			})


### PR DESCRIPTION
When enabled the plugin my traefik instance started to strip CORS headers from the requests. 
This covers the case for unfiltered requests and filtered but approved requests.  